### PR TITLE
added permissions - get & list for task-executor on secrets, configmaps and PVCs

### DIFF
--- a/hkube/templates/task-executor-role.yaml
+++ b/hkube/templates/task-executor-role.yaml
@@ -21,7 +21,7 @@ rules:
   resources: ["pods", "resourcequotas"]
   verbs: ["get", "list", "watch"]
 - apiGroups: [""]
-  resources: ["configmaps, "persistentvolumeclaims", "secrets"]
+  resources: ["configmaps", "persistentvolumeclaims", "secrets"]
   verbs: ["get", "list", "watch"]
 - apiGroups: ["batch"]
   resources: ["jobs"]

--- a/hkube/templates/task-executor-role.yaml
+++ b/hkube/templates/task-executor-role.yaml
@@ -21,8 +21,8 @@ rules:
   resources: ["pods", "resourcequotas"]
   verbs: ["get", "list", "watch"]
 - apiGroups: [""]
-  resources: ["configmaps"]
-  verbs: ["get"]
+  resources: ["configmaps, "persistentvolumeclaims", "secrets"]
+  verbs: ["get", "list", "watch"]
 - apiGroups: ["batch"]
   resources: ["jobs"]
   verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
@@ -59,6 +59,9 @@ rules:
   verbs: ["get", "watch", "list"]
 - apiGroups: [""]
   resources: ["pods"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: [""]
+  resources: ["configmaps", "persistentvolumeclaims", "secrets"]
   verbs: ["get", "list", "watch"]
 ---
 kind: ClusterRoleBinding
@@ -108,6 +111,9 @@ rules:
 - apiGroups: ["batch"]
   resources: ["jobs"]
   verbs: ["delete"]
+- apiGroups: [""]
+  resources: ["configmaps", "persistentvolumeclaims", "secrets"]
+  verbs: ["get", "list"]
 # - apiGroups: ["apiextensions.k8s.io"]
 #   resources: ["customresourcedefinitions"]
 #   verbs: ["get"]
@@ -142,6 +148,9 @@ rules:
 - apiGroups: ["apiextensions.k8s.io"]
   resources: ["customresourcedefinitions"]
   verbs: ["get"]
+- apiGroups: [""]
+  resources: ["configmaps", "persistentvolumeclaims", "secrets"]
+  verbs: ["get", "list"]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
Related to this issue: https://github.com/kube-HPC/hkube/issues/1821
Requried for this PR: https://github.com/kube-HPC/hkube/pull/2033

Added permissions to get and list PVCs, Secrets, and ConfigMaps for the task-executor, allowing it to retrieve details about these resources.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kube-HPC/helm/124)
<!-- Reviewable:end -->
