### PR TITLE
Hkube status fix v and x

### DIFF
--- a/hkube/dashboards/grafana_dashboards/Hkube-Status.json
+++ b/hkube/dashboards/grafana_dashboards/Hkube-Status.json
@@ -8,6 +8,12 @@
         "hide": true,
         "iconColor": "rgba(0, 211, 255, 1)",
         "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
+          "type": "dashboard"
+        },
         "type": "dashboard"
       }
     ]
@@ -15,8 +21,10 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 14,
+  "id": 37,
+  "iteration": 1741692441615,
   "links": [],
+  "liveNow": false,
   "panels": [
     {
       "collapsed": false,
@@ -81,7 +89,7 @@
       },
       "gridPos": {
         "h": 8,
-        "w": 24,
+        "w": 8,
         "x": 0,
         "y": 1
       },
@@ -96,20 +104,22 @@
           "calcs": [
             "last"
           ],
+          "fields": "",
           "values": false
-        }
+        },
+        "textMode": "auto"
       },
-      "pluginVersion": "6.7.3",
+      "pluginVersion": "8.4.2",
       "repeat": "hkube3rdparty",
       "repeatDirection": "h",
       "targets": [
         {
           "datasource": "${grafana_data_source}",
           "expr": "count(kube_pod_status_phase{phase='Running',pod=~'.+$hkube3rdparty.*'})",
-          "legendFormat": "$hkube3rdparty Status",
           "format": "time_series",
           "instant": true,
           "interval": "",
+          "legendFormat": "$hkube3rdparty Status",
           "refId": "A"
         }
       ],
@@ -179,7 +189,7 @@
       },
       "gridPos": {
         "h": 9,
-        "w": 24,
+        "w": 2.1818181818181817,
         "x": 0,
         "y": 10
       },
@@ -194,18 +204,20 @@
           "calcs": [
             "last"
           ],
+          "fields": "",
           "values": false
-        }
+        },
+        "textMode": "auto"
       },
-      "pluginVersion": "6.7.3",
+      "pluginVersion": "8.4.2",
       "repeat": "hkubeservices",
       "repeatDirection": "h",
       "targets": [
         {
           "datasource": "${grafana_data_source}",
           "expr": "count(kube_pod_status_phase{phase='Running',pod=~'$hkubeservices.*'})",
-          "legendFormat": "$hkubeservices Status",
           "interval": "",
+          "legendFormat": "$hkubeservices Status",
           "refId": "A"
         }
       ],
@@ -213,20 +225,28 @@
       "type": "stat"
     }
   ],
-  "preload": false,
   "refresh": "5s",
-  "schemaVersion": 40,
+  "schemaVersion": 35,
+  "style": "dark",
   "tags": [],
   "templating": {
     "list": [
       {
         "current": {
-          "text": "$__all",
+          "selected": true,
+          "text": "All",
           "value": "$__all"
         },
+        "hide": 0,
         "includeAll": true,
+        "multi": false,
         "name": "hkubeservices",
         "options": [
+          {
+            "selected": true,
+            "text": "All",
+            "value": "$__all"
+          },
           {
             "selected": false,
             "text": "algorithm-operator",
@@ -284,16 +304,25 @@
           }
         ],
         "query": "algorithm-operator,api-server,artifacts-registry,datasources-service,gc-service,pipeline-driver-queue,resource-manager,simulator,sync-server,task-executor,trigger-service",
+        "skipUrlSync": false,
         "type": "custom"
       },
       {
         "current": {
-          "text": "$__all",
+          "selected": true,
+          "text": "All",
           "value": "$__all"
         },
+        "hide": 0,
         "includeAll": true,
+        "multi": false,
         "name": "hkube3rdparty",
         "options": [
+          {
+            "selected": true,
+            "text": "All",
+            "value": "$__all"
+          },
           {
             "selected": false,
             "text": "etcd",
@@ -311,12 +340,15 @@
           }
         ],
         "query": "etcd,mongodb,redis",
+        "skipUrlSync": false,
         "type": "custom"
       },
       {
-        "baseFilters": [],
         "filters": [],
+        "hide": 0,
+        "label": "",
         "name": "Filters",
+        "skipUrlSync": false,
         "type": "adhoc"
       }
     ]
@@ -325,7 +357,20 @@
     "from": "now-5m",
     "to": "now"
   },
-  "timepicker": {},
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ]
+  },
   "timezone": "",
   "title": "Hkube Services",
   "uid": "uXoXQ8Z7k",


### PR DESCRIPTION
Fixed the behavior of the Grafana dashboard (`Hkube-Status`) after updating the Grafana version:

* The query, which counts running pods by name, now returns the correct number of pods related to the service (e.g., etcd, redis). The value correctly changes to ✔ when any pod is running for the service and ❌ when none are running.

* Added a custom label to the graph's legend for better clarity in the tooltip.

Also, updated test environment Grafana to the CICD version Grafana.
The Grafana version this change applied to is: `Grafana v11.3.0 (d9455ff7db)`
Related issue: https://github.com/kube-HPC/hkube/issues/1996

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kube-HPC/helm/131)
<!-- Reviewable:end -->
