### PR TITLE
Custom dashboard data source, filtering by prefix and namespace support

### DIFF
--- a/hkube/dashboards/grafana_dashboards/Hkube-Status.json
+++ b/hkube/dashboards/grafana_dashboards/Hkube-Status.json
@@ -115,7 +115,7 @@
       "targets": [
         {
           "datasource": "${grafana_data_source}",
-          "expr": "count(kube_pod_status_phase{phase='Running',pod=~'.+$hkube3rdparty.*'})",
+          "expr": "count(kube_pod_status_phase{phase='Running', namespace='${namespace}', pod=~'^${podPrefix}-${hkube3rdparty}.*'})",
           "format": "time_series",
           "instant": true,
           "interval": "",
@@ -215,7 +215,7 @@
       "targets": [
         {
           "datasource": "${grafana_data_source}",
-          "expr": "count(kube_pod_status_phase{phase='Running',pod=~'$hkubeservices.*'})",
+          "expr": "count(kube_pod_status_phase{phase='Running', namespace='${namespace}', pod=~'$hkubeservices.*'})",
           "interval": "",
           "legendFormat": "$hkubeservices Status",
           "refId": "A"

--- a/hkube/templates/configmaps/dashboards-configmaps.yaml
+++ b/hkube/templates/configmaps/dashboards-configmaps.yaml
@@ -21,12 +21,6 @@ items:
         app: hkube
   {{ toYaml $.Values.metrics.grafanaDashboardLabel | indent 6 }}
     data:
-      {{ $dashboardName }}.json: >-
-        {{ $.Files.Get $path | toJson
-          | replace "${grafana_data_source}" $finalDatasource
-          | replace "${namespace}" $namespace
-          | replace "${podPrefix}" $podPrefix
-          | replace "${podCountExpr}" (toString $podCountExpr)
-        }}
+      {{ $dashboardName }}.json: {{ $.Files.Get $path | toJson | replace "${grafana_data_source}" $finalDatasource | replace "${namespace}" $namespace | replace "${podPrefix}" $podPrefix | replace "${podCountExpr}" (toString $podCountExpr) }}
   {{- end }}
 {{- end }}

--- a/hkube/templates/configmaps/dashboards-configmaps.yaml
+++ b/hkube/templates/configmaps/dashboards-configmaps.yaml
@@ -1,6 +1,6 @@
 {{- $placeHolderDict := include "grafanaVersionUtility" . | fromJson }}
-  {{- $podCountExpr := index $placeHolderDict "podCountExpr" }}
-  {{- $grafanaDataSource := index $placeHolderDict "grafanaDataSource" }}
+{{- $podCountExpr := index $placeHolderDict "podCountExpr" }}
+{{- $grafanaDataSource := index $placeHolderDict "grafanaDataSource" }}
 {{- $files := .Files.Glob "dashboards/grafana_dashboards/*.json" }}
 {{- if $files }}
 apiVersion: v1
@@ -8,6 +8,8 @@ kind: ConfigMapList
 items:
 {{- range $path, $fileContents := $files }}
   {{- $dashboardName := regexReplaceAll "(^.*/)(.*)\\.json$" $path "${2}" }}
+  {{- $customDatasourceMap := $.Values.metrics.custom_dashboard_datasources | default dict }}
+  {{- $finalDatasource := get $customDatasourceMap $dashboardName | default $grafanaDataSource }}
   - apiVersion: v1
     kind: ConfigMap
     metadata:
@@ -15,8 +17,8 @@ items:
       namespace: {{ $.Release.Namespace }}
       labels:
         app: hkube
-  {{ toYaml $.Values.metrics.grafanaDashboardLabel | indent 6 }}
+{{ toYaml $.Values.metrics.grafanaDashboardLabel | indent 6 }}
     data:
-      {{ $dashboardName }}.json: {{ $.Files.Get $path | toJson | replace "${grafana_data_source}" $grafanaDataSource | replace "${podCountExpr}" (toString $podCountExpr) }}
-  {{- end }}
+      {{ $dashboardName }}.json: {{ $.Files.Get $path | toJson | replace "${grafana_data_source}" $finalDatasource | replace "${podCountExpr}" (toString $podCountExpr) }}
+{{- end }}
 {{- end }}

--- a/hkube/templates/configmaps/dashboards-configmaps.yaml
+++ b/hkube/templates/configmaps/dashboards-configmaps.yaml
@@ -10,6 +10,8 @@ items:
   {{- $dashboardName := regexReplaceAll "(^.*/)(.*)\\.json$" $path "${2}" }}
   {{- $customDatasourceMap := $.Values.metrics.custom_dashboard_datasources | default dict }}
   {{- $finalDatasource := get $customDatasourceMap $dashboardName | default $grafanaDataSource }}
+  {{- $namespace := $.Values.metrics.grafana_hkube_namespace | default $.Release.Namespace }}
+  {{- $podPrefix := $.Values.metrics.grafana_pod_prefix | default "hkube" }}
   - apiVersion: v1
     kind: ConfigMap
     metadata:
@@ -19,6 +21,12 @@ items:
         app: hkube
 {{ toYaml $.Values.metrics.grafanaDashboardLabel | indent 6 }}
     data:
-      {{ $dashboardName }}.json: {{ $.Files.Get $path | toJson | replace "${grafana_data_source}" $finalDatasource | replace "${podCountExpr}" (toString $podCountExpr) }}
+      {{ $dashboardName }}.json: >-
+        {{ $.Files.Get $path | toJson
+          | replace "${grafana_data_source}" $finalDatasource
+          | replace "${namespace}" $namespace
+          | replace "${podPrefix}" $podPrefix
+          | replace "${podCountExpr}" (toString $podCountExpr)
+        }}
 {{- end }}
 {{- end }}

--- a/hkube/templates/configmaps/dashboards-configmaps.yaml
+++ b/hkube/templates/configmaps/dashboards-configmaps.yaml
@@ -1,6 +1,6 @@
 {{- $placeHolderDict := include "grafanaVersionUtility" . | fromJson }}
-{{- $podCountExpr := index $placeHolderDict "podCountExpr" }}
-{{- $grafanaDataSource := index $placeHolderDict "grafanaDataSource" }}
+  {{- $podCountExpr := index $placeHolderDict "podCountExpr" }}
+  {{- $grafanaDataSource := index $placeHolderDict "grafanaDataSource" }}
 {{- $files := .Files.Glob "dashboards/grafana_dashboards/*.json" }}
 {{- if $files }}
 apiVersion: v1
@@ -19,7 +19,7 @@ items:
       namespace: {{ $.Release.Namespace }}
       labels:
         app: hkube
-{{ toYaml $.Values.metrics.grafanaDashboardLabel | indent 6 }}
+  {{ toYaml $.Values.metrics.grafanaDashboardLabel | indent 6 }}
     data:
       {{ $dashboardName }}.json: >-
         {{ $.Files.Get $path | toJson
@@ -28,5 +28,5 @@ items:
           | replace "${podPrefix}" $podPrefix
           | replace "${podCountExpr}" (toString $podCountExpr)
         }}
-{{- end }}
+  {{- end }}
 {{- end }}

--- a/hkube/values.yaml
+++ b/hkube/values.yaml
@@ -285,9 +285,17 @@ metrics:
   grafana_version: "8"
   # set the name of the data source defined in grafana, where hkube metrics are collected ./dashboards/grafana_dashboards/*.json files
   grafana_data_source: Prometheus
+
+  # Prefix for hkube 3rd party services (only used in 3rd party queries)
+  grafana_pod_prefix: "hkube"
+
+  # Namespace where HKube is deployed
+  grafana_hkube_namespace: "default"
+
   # Optional per-dashboard datasource overrides
   custom_dashboard_datasources:
     Hkube-Status: ""
+
     # used to set 'expr' value in HKube_status.json, replaces the partial string "${podCountExpr}" for grafana_version == 6
   pod_count_expr_v6: "count(mixin_pod_workload{workload="
   # used to set 'expr' value in HKube_status.json, replaces the partial string "${podCountExpr}" for grafana_version == 7

--- a/hkube/values.yaml
+++ b/hkube/values.yaml
@@ -285,6 +285,9 @@ metrics:
   grafana_version: "8"
   # set the name of the data source defined in grafana, where hkube metrics are collected ./dashboards/grafana_dashboards/*.json files
   grafana_data_source: Prometheus
+  # Optional per-dashboard datasource overrides
+  custom_dashboard_datasources:
+    Hkube-Status: ""
     # used to set 'expr' value in HKube_status.json, replaces the partial string "${podCountExpr}" for grafana_version == 6
   pod_count_expr_v6: "count(mixin_pod_workload{workload="
   # used to set 'expr' value in HKube_status.json, replaces the partial string "${podCountExpr}" for grafana_version == 7


### PR DESCRIPTION
In this PR, the following is handled:

- Optional **custom dashboard data sources**, as requested for Hkube-Status dashboard (services). This feature is supported for every dashboard - each one can have a different data source if needed, simply by updating the values file.
- **Filtering hkube 3rd services by prefix** (e.g., hkube). The prefix is now configurable via values.
- **Filtering by namespace** in the Hkube-Status dashboard. The namespace is also configurable via values.

**Related issue** - https://github.com/kube-HPC/hkube/issues/1994

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kube-HPC/helm/134)
<!-- Reviewable:end -->
