### PR TITLE
added new roles for task-executor ClusterRole

### DIFF
--- a/hkube/templates/task-executor-role.yaml
+++ b/hkube/templates/task-executor-role.yaml
@@ -60,6 +60,12 @@ rules:
 - apiGroups: [""]
   resources: ["pods", "configmaps", "secrets", "persistentvolumeclaims"]
   verbs: ["get", "list", "watch"]
+- apiGroups: ["apiextensions.k8s.io"]
+  resources: ["customresourcedefinitions"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["scheduling.run.ai"]
+  resources: ["queues"]
+  verbs: ["get", "list", "watch"]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
Added cluster role for task-executor to be able to read CRDs and queues (custom resource of Kai-Scheduler by run-ai)
Related issue https://github.com/kube-HPC/hkube/issues/2173

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kube-HPC/helm/142)
<!-- Reviewable:end -->
