### PR TITLE
added limit range for task-executor clusterRole

### DIFF
--- a/hkube/templates/task-executor-role.yaml
+++ b/hkube/templates/task-executor-role.yaml
@@ -55,10 +55,7 @@ metadata:
     core: "true"
 rules:
 - apiGroups: [""]
-  resources: ["nodes"]
-  verbs: ["get", "watch", "list"]
-- apiGroups: [""]
-  resources: ["pods", "configmaps", "secrets", "persistentvolumeclaims"]
+  resources: ["nodes", "pods", "configmaps", "secrets", "persistentvolumeclaims", "limitranges"]
   verbs: ["get", "list", "watch"]
 - apiGroups: ["apiextensions.k8s.io"]
   resources: ["customresourcedefinitions"]


### PR DESCRIPTION
Added for task-executor clusterRole permission to get. list or watch limitRanges.
Needed because this PR: https://github.com/kube-HPC/hkube/pull/2224 and should be merged before it.
Related issue - https://github.com/kube-HPC/hkube/issues/2185